### PR TITLE
Hide email address in RSS feeds

### DIFF
--- a/Checklist.Nederlands.md
+++ b/Checklist.Nederlands.md
@@ -11,6 +11,7 @@ Checklist ter controle voor livegang van een nieuwe Joomla! website:
 * Standaard Captcha ingesteld?
 * Foutrapportage uitgeschakeld?
 * Algemeen e-mailadres website ingesteld?
+* Feed Email Address op "No Email"?
 * SMTP server ingesteld in de e-mailinstellingen?
 * Groepsmail uitgeschakeld?
 * Tijdzone server goed ingesteld?


### PR DESCRIPTION
Spambots indexeren email adressen via RSS / ATOM feeds, ook als die uit staan.