### PR TITLE
change from myjoomla.com to mySites.guru

### DIFF
--- a/Checklist.English.md
+++ b/Checklist.English.md
@@ -83,7 +83,7 @@ Checklist for when a Joomla! website goes live:
 ## Extras
 * Google Analytics setup?
 * Watchful.li setup? ([Watchful.li](https://watchful.li/))
-* myJoomla audit done? ([{manage}.myJoomla.com](https://myjoomla.com/))
+* mySites.guru audit done? ([mySites.guru](https://mySites.guru/))
 * Joomla Update Notification plugin published/unpublished?
 * Is there a backup scheme?
 * Backup AND restore tested?

--- a/Checklist.Nederlands.md
+++ b/Checklist.Nederlands.md
@@ -83,7 +83,7 @@ Checklist ter controle voor livegang van een nieuwe Joomla! website:
 ## Diversen
 * Google Analytics ingesteld?
 * Watchful.li ingesteld? ([Watchful.li](https://watchful.li/))
-* myJoomla audit gedaan? ([{manage}.myJoomla.com](https://myjoomla.com/))
+* mySites.guru audit gedaan? ([mySites.guru](https://mySites.guru/))
 * Joomla Updatemelding plugin gepubliceerd/gedepubliceerd?
 * Backupschema actief?
 * Backup EN restore getest?


### PR DESCRIPTION
myJoomla.com has been rebranded to mySites.guru for several years now.

This PR changes the markdown files to have the correct domain

Please note I have not updated the docx files as I do not have Microsoft Word on my Mac. Please update those links too. 

Kindest regards 
Phil
